### PR TITLE
Modify LECAP scraper to skip corrupted rows

### DIFF
--- a/PROJECT.md
+++ b/PROJECT.md
@@ -89,6 +89,7 @@ financemonitor/
   1. Populate assets not in dim_asset using the transaction's data.
   1. Create a new LookerStudio dashboard.
 - Migrate the LECAP' scraper.
+  - Lecap scraper should skip corrupted rows, not fail the whole process.
 - Add/migrate the IOL code.
 - Expose endpoints for the Portfolio API to query on demand values. This could be a Cloud Function.
 - Consider integrating yfinance to work aroung the AV daily limit.


### PR DESCRIPTION
Update migration tasks for LECAP scraper to handle corrupted rows.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * LECAP scraper now skips corrupted rows instead of failing the entire process.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->